### PR TITLE
add checking for dataclass and refactor

### DIFF
--- a/pyeo/features/no_mutable_objects.py
+++ b/pyeo/features/no_mutable_objects.py
@@ -60,21 +60,25 @@ class NoMutableObjectsVisitor(ast.NodeVisitor):
                             frozen_found = True
                             break
                 elif isinstance(deco.func, ast.Attribute) and deco.func.attr == 'define':
-                    for keyword in deco.keywords:
-                        if keyword.arg == 'frozen' and keyword.value.value:
-                            frozen_found = True
-                            break
+                    frozen_found = self._frozen(deco.keywords)
                 elif isinstance(deco.func, ast.Name) and deco.func.id == 'define':
-                    for keyword in deco.keywords:
-                        if keyword.arg == 'frozen' and keyword.value.value:
-                            frozen_found = True
-                            break
+                    frozen_found = self._frozen(deco.keywords)
                 elif isinstance(deco.func, ast.Name) and deco.func.id == 'frozen':
                     frozen_found = True
                     break
+                elif isinstance(deco.func, ast.Attribute) and deco.func.attr == "dataclass":
+                    frozen_found = self._frozen(deco.keywords)
+                elif isinstance(deco.func, ast.Name) and deco.func.id == 'dataclass':
+                    frozen_found = self._frozen(deco.keywords)
                 elif deco.func.value.id == 'attrs' and deco.func.attr == 'frozen':
                     frozen_found = True
                     break
         if not frozen_found:
             self.problems.append((node.lineno, node.col_offset, 'PEO200 class must be frozen'))
         self.generic_visit(node)
+
+    def _frozen(self, keywords: list[ast.keyword]) -> bool:
+        for keyword in keywords:
+            if keyword.arg == 'frozen' and keyword.value.value:
+                return True
+        return False

--- a/pyeo/features/no_mutable_objects.py
+++ b/pyeo/features/no_mutable_objects.py
@@ -66,7 +66,7 @@ class NoMutableObjectsVisitor(ast.NodeVisitor):
                 elif isinstance(deco.func, ast.Name) and deco.func.id == 'frozen':
                     frozen_found = True
                     break
-                elif isinstance(deco.func, ast.Attribute) and deco.func.attr == "dataclass":
+                elif isinstance(deco.func, ast.Attribute) and deco.func.attr == 'dataclass':
                     frozen_found = self._frozen(deco.keywords)
                 elif isinstance(deco.func, ast.Name) and deco.func.id == 'dataclass':
                     frozen_found = self._frozen(deco.keywords)

--- a/tests/features/test_no_mutable_objects.py
+++ b/tests/features/test_no_mutable_objects.py
@@ -60,6 +60,8 @@ def test_skip_with_base(plugin_run, base_class, options_factory):
     '@frozen',
     '@attrs.frozen()',
     '@frozen()',
+    '@dataclass(frozen=True)',
+    '@dataclasses.dataclass(frozen=True)',
 ])
 def test_valid(plugin_run, decorator, options_factory):
     got = plugin_run(


### PR DESCRIPTION
```sh
$ pytest -v
============================================================== test session starts ==============================================================
platform linux -- Python 3.13.3, pytest-8.3.4, pluggy-1.5.0 -- /home/rafail-2/.cache/pypoetry/virtualenvs/eo-styleguide-VSQLzLiP-py3.13/bin/python
cachedir: .pytest_cache
rootdir: /home/rafail-2/pyeo
configfile: pyproject.toml
plugins: anyio-4.7.0
collected 31 items

tests/features/test_code_free_ctor.py::test PASSED                                                                                        [  3%]
tests/features/test_code_free_ctor.py::test_ctor_docstring PASSED                                                                         [  6%]
tests/features/test_code_free_ctor.py::test_ctor_typehint PASSED                                                                          [  9%]
tests/features/test_code_free_ctor.py::test_ctor_with_code PASSED                                                                         [ 12%]
tests/features/test_forbidden_decorator_visitor.py::test_valid PASSED                                                                     [ 16%]
tests/features/test_forbidden_decorator_visitor.py::test_staticmethod PASSED                                                              [ 19%]
tests/features/test_no_er_suffix.py::test_forbidden[er] PASSED                                                                            [ 22%]
tests/features/test_no_er_suffix.py::test_whitelist[User] PASSED                                                                          [ 25%]
tests/features/test_no_er_suffix.py::test_whitelist_from_options[Answer] PASSED                                                           [ 29%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[Protocol] PASSED                                                           [ 32%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[typing.Protocol] PASSED                                                    [ 35%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[t.Protocol] PASSED                                                         [ 38%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[t.Protocol, OtherClass] PASSED                                             [ 41%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[OtherClass, Protocol] PASSED                                               [ 45%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[OtherClass, t.Protocol] PASSED                                             [ 48%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[Protocol[Mammal]] PASSED                                                   [ 51%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[Exception] PASSED                                                          [ 54%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[AppError] PASSED                                                           [ 58%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[TypedDict] PASSED                                                          [ 61%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[typing.TypedDict] PASSED                                                   [ 64%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[t.TypedDict] PASSED                                                        [ 67%]
tests/features/test_no_mutable_objects.py::test_skip_with_base[Enum] PASSED                                                               [ 70%]
tests/features/test_no_mutable_objects.py::test_valid[@attrs.define(frozen=True)] PASSED                                                  [ 74%]
tests/features/test_no_mutable_objects.py::test_valid[@define(frozen=True)] PASSED                                                        [ 77%]
tests/features/test_no_mutable_objects.py::test_valid[@attrs.frozen] PASSED                                                               [ 80%]
tests/features/test_no_mutable_objects.py::test_valid[@frozen] PASSED                                                                     [ 83%]
tests/features/test_no_mutable_objects.py::test_valid[@attrs.frozen()] PASSED                                                             [ 87%]
tests/features/test_no_mutable_objects.py::test_valid[@frozen()] PASSED                                                                   [ 90%]
tests/features/test_no_mutable_objects.py::test_valid[@dataclass(frozen=True)] PASSED                                                     [ 93%]
tests/features/test_no_mutable_objects.py::test_valid[@dataclasses.dataclass(frozen=True)] PASSED                                         [ 96%]
tests/features/test_no_mutable_objects.py::test_invalid PASSED                                                                            [100%]

============================================================== 31 passed in 0.03s ===============================================================

```

Fix #67 